### PR TITLE
Update grep.sh

### DIFF
--- a/bin/profile.d/alias.sh
+++ b/bin/profile.d/alias.sh
@@ -25,3 +25,18 @@ if ( echo $- | grep i >/dev/null 2>&1 ); then
     fi
 
 fi
+
+my_grep_options=(--color=auto) # I like color, without deprecation warnings
+
+if ( _version_gte "$( grep -V | head -n 1 | sed 's/[^0-9]*\([0-9]*\.[0-9]*\).*/\1/' )" "2.5.2" ); then
+    # The following adds new options for grep to exclude: CVS, .cvs, .git, .hg, .svn directories
+    my_grep_options=(
+        ${my_grep_options[@]} --exclude-dir=CVS)    # Excludes CVS directories for CVS
+        ${my_grep_options[@]} --exclude-dir=.cvs)   # Excludes .cvs directories for CVS
+        ${my_grep_options[@]} --exclude-dir=.git)   # Excludes .git directories for Git
+        ${my_grep_options[@]} --exclude-dir=.hg)    # Excludes .hg directories for Mercurial
+        ${my_grep_options[@]} --exclude-dir=.svn)   # Excludes .svn directors for Subversion
+    )
+    alias grep="grep $my_grep_options"
+    unset my_grep_options
+fi

--- a/bin/profile.d/grep.sh
+++ b/bin/profile.d/grep.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-my_grep_options=(--color=auto) # I like color, without deprecation warnings
-
-if ( _version_gte "$( grep -V | head -n 1 | sed 's/[^0-9]*\([0-9]*\.[0-9]*\).*/\1/' )" "2.5.2" ); then
-    # The following adds new options for grep to exclude: CVS, .cvs, .git, .hg, .svn directories
-    my_grep_options=(${my_grep_options[@]}  --exclude-dir=.cvs --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=CVS)
-    alias grep="${BASH_ALIASES[grep]:-grep} my_grep_options"
-fi

--- a/bin/profile.d/grep.sh
+++ b/bin/profile.d/grep.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 
-export GREP_OPTIONS=""
-export GREP_OPTIONS="$GREP_OPTIONS"' --colour=auto' # I like color
+my_grep_options=(--color=auto) # I like color, without deprecation warnings
 
 if ( _version_gte "$( grep -V | head -n 1 | sed 's/[^0-9]*\([0-9]*\.[0-9]*\).*/\1/' )" "2.5.2" ); then
-    export GREP_OPTIONS="$GREP_OPTIONS"' --exclude-dir="CVS"' # Exclude CVS directories
-    export GREP_OPTIONS="$GREP_OPTIONS"' --exclude-dir=".svn"' # Exclude Subversion directories
-    export GREP_OPTIONS="$GREP_OPTIONS"' --exclude-dir=".git"' # Exclude Git directory
+    # The following adds new options for grep to exclude: CVS, .cvs, .git, .hg, .svn directories
+    my_grep_options=(${my_grep_options[@]}  --exclude-dir=.cvs --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=CVS)
+    alias grep="${BASH_ALIASES[grep]:-grep} my_grep_options"
 fi


### PR DESCRIPTION
Modifying to remove the references to the now deprecated `GREP_OPTIONS` which throws a deprecation warning.